### PR TITLE
Fix round for price in order_send function

### DIFF
--- a/lib/private_api.rb
+++ b/lib/private_api.rb
@@ -76,7 +76,7 @@ module PrivateApi
       pair: pair,
       type: order_type,
       volume: volume.to_d.round(6).to_f.to_s,
-      price: price.to_f.round.to_s
+      price: price.to_f.round(2).to_s
     }
     opt.merge!({params: params, method: :post})
     path = '/api/1/postorder'


### PR DESCRIPTION
Hello!
In the current implementation of function `post_order` we cannot set price with two digits after comma like 5500.95 because the price value will be rounded to integer (5500.95 will be rounded to 5501).
I add an additional argument to round function for price value. Please, merge it to upstream.